### PR TITLE
Escape double quotes within passwords

### DIFF
--- a/chrome-export.js
+++ b/chrome-export.js
@@ -31,7 +31,7 @@ setTimeout(
 						+ item.childNodes[0].childNodes[2].childNodes[0].value;
 				out2 += '<br/>"http://' + model.array_[i].shownUrl + '","'
 						+ model.array_[i].username + '","'
-						+ item.childNodes[0].childNodes[2].childNodes[0].value
+						+ item.childNodes[0].childNodes[2].childNodes[0].value.replace(/"/g, '""')
 						+ '","' + model.array_[i].origin + '"," "," "," "';
 			}
 			;


### PR DESCRIPTION
"A double-quote appearing inside a field must be escaped by preceding it with another double quote."
From section 2.7: https://tools.ietf.org/html/rfc4180#section-2
